### PR TITLE
CartModule, 28: renaming controller methods to fix Swagger validation errors

### DIFF
--- a/VirtoCommerce.CatalogPublishingModule.Web/Controllers/Api/CompletenessController.cs
+++ b/VirtoCommerce.CatalogPublishingModule.Web/Controllers/Api/CompletenessController.cs
@@ -61,7 +61,7 @@ namespace VirtoCommerce.CatalogPublishingModule.Web.Controllers.Api
         [Route("channels/{id}/evaluate")]
         [ResponseType(typeof(PushNotification))]
         [CheckPermission(Permission = ChannelPredefinedPermissions.Update)]
-        public IHttpActionResult EvaluateCompleteness(string id)
+        public IHttpActionResult EvaluateChannelCompleteness(string id)
         {
             return EvaluateCompleteness("EvaluateCompleteness", "Evaluate completeness task", notification => BackgroundJob.Enqueue(() => EvaluateCompletenessJob(id, notification)));
         }
@@ -73,7 +73,7 @@ namespace VirtoCommerce.CatalogPublishingModule.Web.Controllers.Api
         [HttpPost]
         [Route("channels/{id}/products/evaluate")]
         [ResponseType(typeof(CompletenessEntry[]))]
-        public IHttpActionResult EvaluateCompleteness(string id, [FromBody] string[] productIds)
+        public IHttpActionResult EvaluateProductsCompleteness(string id, [FromBody] string[] productIds)
         {
             var channel = _completenessService.GetChannelsByIds(new[] { id }).FirstOrDefault();
             if (channel == null)


### PR DESCRIPTION
This PR is a part of the VirtoCommerce/vc-module-cart#28. It fixes the Swagger validation error caused by multiple entries having the same `operationId` value (Swashbuckle generates it like `{controllerName}_{actionMethodName}`) by renaming controller methods. I have not changed routes for these methods, so this change shouldn't break anything.