### PR TITLE
VCST-4880: The model context has pending changes for MySQL

### DIFF
--- a/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
@@ -16,6 +16,6 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
@@ -16,6 +16,6 @@
   <ItemGroup>
     
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/Migrations/20260406162913_FixPendingModelChangesWarning.Designer.cs
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/Migrations/20260406162913_FixPendingModelChangesWarning.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.CatalogPublishingModule.Data.Repositories;
 
@@ -11,9 +12,11 @@ using VirtoCommerce.CatalogPublishingModule.Data.Repositories;
 namespace VirtoCommerce.CatalogPublishingModule.Data.MySql.Migrations
 {
     [DbContext(typeof(CatalogPublishingDbContext))]
-    partial class CatalogPublishingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260406162913_FixPendingModelChangesWarning")]
+    partial class FixPendingModelChangesWarning
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/Migrations/20260406162913_FixPendingModelChangesWarning.cs
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/Migrations/20260406162913_FixPendingModelChangesWarning.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.CatalogPublishingModule.Data.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixPendingModelChangesWarning : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CompletenessPercent",
+                table: "CompletenessEntry",
+                type: "decimal(65,30)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CompletenessPercent",
+                table: "CompletenessDetail",
+                type: "decimal(65,30)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CompletenessPercent",
+                table: "CompletenessChannel",
+                type: "decimal(65,30)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CompletenessPercent",
+                table: "CompletenessEntry",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(65,30)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CompletenessPercent",
+                table: "CompletenessDetail",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(65,30)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "CompletenessPercent",
+                table: "CompletenessChannel",
+                type: "decimal(18,2)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(65,30)",
+                oldNullable: true);
+        }
+    }
+}

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/VirtoCommerce.CatalogPublishingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/VirtoCommerce.CatalogPublishingModule.Data.MySql.csproj
@@ -3,15 +3,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/VirtoCommerce.CatalogPublishingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/VirtoCommerce.CatalogPublishingModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.1
+dotnet tool install --global dotnet-ef --version 10.0.5
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.1
+dotnet tool update --global dotnet-ef --version 10.0.5
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/VirtoCommerce.CatalogPublishingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/VirtoCommerce.CatalogPublishingModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/VirtoCommerce.CatalogPublishingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/VirtoCommerce.CatalogPublishingModule.Data.SqlServer.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data/VirtoCommerce.CatalogPublishingModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data/VirtoCommerce.CatalogPublishingModule.Data.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.CatalogPublishingModule.Data/VirtoCommerce.CatalogPublishingModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data/VirtoCommerce.CatalogPublishingModule.Data.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/VirtoCommerce.CatalogPublishingModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/VirtoCommerce.CatalogPublishingModule.Web.csproj
@@ -21,7 +21,7 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Core\VirtoCommerce.CatalogPublishingModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/VirtoCommerce.CatalogPublishingModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/VirtoCommerce.CatalogPublishingModule.Web.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>False</IsPackable>
-    <noWarn>1591;NU1608</noWarn>
+    <noWarn>1591</noWarn>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>
@@ -21,7 +21,7 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1013.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0-alpha.13231-vcst-4880-mysql" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Core\VirtoCommerce.CatalogPublishingModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.CatalogPublishing</id>
   <version>3.1002.0</version>
   <version-tag />
-  <platformVersion>3.1013.0</platformVersion>
+  <platformVersion>3.1016.0-alpha.13231-vcst-4880-mysql</platformVersion>
 
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.CatalogPublishing</id>
   <version>3.1002.0</version>
   <version-tag />
-  <platformVersion>3.1016.0-alpha.13231-vcst-4880-mysql</platformVersion>
+  <platformVersion>3.1016.0</platformVersion>
 
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/package-lock.json
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/package-lock.json
@@ -380,15 +380,16 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -472,9 +473,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -852,6 +853,23 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -1313,10 +1331,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -1714,25 +1733,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -1814,27 +1814,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -1866,16 +1845,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -2001,16 +1970,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -2070,15 +2038,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {


### PR DESCRIPTION
## Description
fix: The model context has pending changes for MySQL

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4880
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogPublishing_3.1002.0-pr-74-76af.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes a MySQL schema migration that changes `CompletenessPercent` column precision/scale, which can affect existing data/storage and may take locks during deployment. Remaining changes are dependency/version bumps with comparatively low behavioral risk but could introduce compatibility issues with the updated platform/EF packages.
> 
> **Overview**
> Fixes MySQL EF Core "pending model changes" by adding a new MySQL migration that alters `CompletenessPercent` columns in `CompletenessChannel`, `CompletenessEntry`, and `CompletenessDetail` from `decimal(18,2)` to `decimal(65,30)` (and updates the MySQL model snapshot/EF product version).
> 
> Bumps VirtoCommerce Platform dependencies across Core/Data/Web (and `module.manifest` platform version) from `3.1013.0` to `3.1016.0`, updates EF tooling/docs to `dotnet-ef`/`Microsoft.EntityFrameworkCore.Design` `10.0.5`, and refreshes the web `package-lock.json` (notably `ajv` and related transitive packages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76afbfd638164400467a39083f5d91b2bd905ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->