### PR TITLE
VCST-4516: Update SEO widget mapper to use Seo module controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,6 @@
 {
-  "lockfileVersion": 1
+  "name": "vc-module-catalog-publishing",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
 }

--- a/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1017.0-alpha.2497-vcst-4516" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
@@ -14,8 +14,8 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1017.0-alpha.2497-vcst-4516" />
+
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1019.0" />
     <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/Scripts/catalog-publishing.js
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/Scripts/catalog-publishing.js
@@ -61,7 +61,7 @@ angular.module(moduleName, [])
         widgetMapperService.map("Properties", "virtoCommerce.catalogModule.itemPropertyWidgetController");
         widgetMapperService.map("Descriptions", "virtoCommerce.catalogModule.editorialReviewWidgetController");
         widgetMapperService.map("Prices", "virtoCommerce.pricingModule.itemPricesWidgetController");
-        widgetMapperService.map("Seo", "virtoCommerce.coreModule.seo.seoWidgetController");
+        widgetMapperService.map("Seo", "virtoCommerce.seo.seoWidgetController");
 
         const menuExportTemplate = {
             priority: 900,

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
@@ -6,7 +6,7 @@
   <platformVersion>3.1016.0</platformVersion>
 
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1017.0-alpha.2497-vcst-4516" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1019.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
   </dependencies>
 

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
@@ -6,7 +6,7 @@
   <platformVersion>3.1016.0</platformVersion>
 
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1017.0-alpha.2497-vcst-4516" />
     <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
   </dependencies>
 


### PR DESCRIPTION
## Description

- Updated completeness widget mapper to reference SEO widget controller from VirtoCommerce.Seo module instead of Core

### Changes

**catalog-publishing.js**:
- `widgetMapperService.map("Seo", "virtoCommerce.coreModule.seo.seoWidgetController")` → `widgetMapperService.map("Seo", "virtoCommerce.seo.seoWidgetController")`

### Related

Companion PRs: vc-module-seo, vc-module-core, vc-module-catalog, vc-module-store, vc-module-customer, vc-docs

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4516
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogPublishing_3.1003.0-pr-75-c219.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity changes, but they update module dependencies and the npm lockfile format/version, which can affect build/release reproducibility and runtime compatibility if consumers aren’t aligned.
> 
> **Overview**
> Updates the catalog publishing UI to map the `Seo` completeness widget to `virtoCommerce.seo.seoWidgetController` instead of the legacy Core controller.
> 
> Bumps the Catalog module dependency to `3.1019.0` (in both `.csproj` and `module.manifest`) and modernizes `package-lock.json` (lockfile v1 → v3 with package metadata).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c219b6e8df9f487895bc932c41acdd8fdca49c9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->