### PR TITLE
VCST-5163: Stable 15 — CatalogPublishing (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Core/VirtoCommerce.CatalogPublishingModule.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
 
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1019.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/VirtoCommerce.CatalogPublishingModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.MySql/VirtoCommerce.CatalogPublishingModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql/VirtoCommerce.CatalogPublishingModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/VirtoCommerce.CatalogPublishingModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data.SqlServer/VirtoCommerce.CatalogPublishingModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Data\VirtoCommerce.CatalogPublishingModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Data/VirtoCommerce.CatalogPublishingModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Data/VirtoCommerce.CatalogPublishingModule.Data.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
-    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Core\VirtoCommerce.CatalogPublishingModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/VirtoCommerce.CatalogPublishingModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/VirtoCommerce.CatalogPublishingModule.Web.csproj
@@ -21,7 +21,7 @@
     <None Remove="node_modules\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1016.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPublishingModule.Core\VirtoCommerce.CatalogPublishingModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogPublishingModule.Web/module.manifest
@@ -3,11 +3,11 @@
   <id>VirtoCommerce.CatalogPublishing</id>
   <version>3.1005.0</version>
   <version-tag />
-  <platformVersion>3.1016.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
 
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1019.0" />
-    <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Pricing" version="3.1003.0" />
   </dependencies>
 
   <title>Catalog Publishing</title>

--- a/tests/VirtoCommerce.CatalogPublishingModule.Test/VirtoCommerce.CatalogPublishingModule.Test.csproj
+++ b/tests/VirtoCommerce.CatalogPublishingModule.Test/VirtoCommerce.CatalogPublishingModule.Test.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <noWarn>1591</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 6). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–5 packages on nuget.org. Version handled by CI.

- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application or API logic changes—only dependency and manifest version alignment for the Stable 15 wave.
> 
> **Overview**
> Aligns **Catalog Publishing** with **Stable 15** by retargeting Virto Commerce packages to platform **3.1039.0** and updated Catalog/Pricing module versions across Core, Data (including MySQL/PostgreSQL/SQL Server), and Web.
> 
> `module.manifest` now declares **platformVersion 3.1039.0** and dependency pins **VirtoCommerce.Catalog 3.1029.0** and **VirtoCommerce.Pricing 3.1003.0**, matching the csproj `PackageReference` updates. The test project bumps **coverlet.collector** from 8.0.0 to **10.0.1** and removes a BOM from the project file opening tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4baf7c5a4f4b090a14ee0e9a60e9713a26e0323c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogPublishing_3.1005.0-pr-77-4baf.zip